### PR TITLE
generate_aliases , merge_aliases in ImageRef class implemented

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     msgpack~=0.6.0
     setproctitle~=1.1.10
     python-json-logger
+    packaging
 
 [options.packages.find]
 where = src

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -366,30 +366,21 @@ class ImageRef:
             raise ValueError('only the image-refs with same names can be compared.')
         if self.tag_set[0] != other.tag_set[0]:
             return version.parse(self.tag_set[0]) < version.parse(other.tag_set[0])
-        else:
-            ptagset_self, ptagset_other = self.tag_set[1], other.tag_set[1]
-            it = iter(ptagset_self)
-            while True:
-                key_self = next(it, None)
-                if key_self == None: #comparison complete
-                    return len(ptagset_self) > len(ptagset_other)
-                elif ptagset_other.has(key_self):
-                    version_self, version_other = ptagset_self.get(key_self), ptagset_other.get(key_self)
-                    if version_self and version_other:
-                        parsed_version_self, parsed_version_other = version.parse(version_self), version.parse(version_other)
-                        if parsed_version_self != parsed_version_other:
-                            return parsed_version_self < parsed_version_other
-
-        # ImageRef('...:ubuntu') < ImageRef('...:ubuntu16.04')
-        # ImageRef('...:ubuntu') > ImageRef('...:ubuntu16.04')
-        # both will return False in this implementation, since length same.
-        # -> can this be solved by naming convention of images?
+        ptagset_self, ptagset_other = self.tag_set[1], other.tag_set[1]
+        it = iter(ptagset_self)
+        for key_self in ptagset_self:
+            if ptagset_other.has(key_self):
+                version_self, version_other = ptagset_self.get(key_self), ptagset_other.get(key_self)
+                if version_self and version_other:
+                    parsed_version_self, parsed_version_other = version.parse(version_self), version.parse(version_other)
+                    if parsed_version_self != parsed_version_other:
+                        return parsed_version_self < parsed_version_other
+        return len(ptagset_self) > len(ptagset_other)
 
 
 class DeviceTypes(enum.Enum):
     CPU = 'cpu'
     MEMORY = 'mem'
-
 
 DeviceType = NewType('DeviceType', Union[str, DeviceTypes])
 

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -263,22 +263,20 @@ class ImageRef:
                     tag_list.append(tag_key + tag_ver.rsplit('.')[0])
                 elif tag_key == 'py' and len(tag_ver) > 1:
                     tag_list.append(tag_key + tag_ver[0])
-                
                 if 'cuda' in tag_key:
                     tag_list.append('gpu')
-
                 possible_ptags.append(tag_list)
-        
+
         ret = {}
         for name in possible_names:
             ret[name] = self
-        for name, ptags in itertools.product (
+        for name, ptags in itertools.product(
                 possible_names,
                 itertools.product(*possible_ptags)):
             ret[f"{name}:{'-'.join(t for t in ptags if t)}"] = self
         return ret
 
-    @staticmethod            
+    @staticmethod
     def merge_aliases(genned_aliases_1, genned_aliases_2) -> Mapping[str, 'ImageRef']:
         ret = {}
         aliases_set_1, aliases_set_2 = set(genned_aliases_1.keys()), set(genned_aliases_2.keys())
@@ -286,12 +284,12 @@ class ImageRef:
 
         for alias in aliases_dup:
             ret[alias] = max(genned_aliases_1[alias], genned_aliases_2[alias])
-            
+
         for alias in aliases_set_1 - aliases_dup:
             ret[alias] = genned_aliases_1[alias]
         for alias in aliases_set_2 - aliases_dup:
             ret[alias] = genned_aliases_2[alias]
-        
+
         return ret
 
     @property
@@ -360,14 +358,13 @@ class ImageRef:
         return hash((self._name, self._tag, self._registry))
 
     def __lt__(self, other) -> bool:
-        if self == other: #call __eq__ first for resolved check
+        if self == other:   # call __eq__ first for resolved check
             return False
         if self.name != other.name:
             raise ValueError('only the image-refs with same names can be compared.')
         if self.tag_set[0] != other.tag_set[0]:
             return version.parse(self.tag_set[0]) < version.parse(other.tag_set[0])
         ptagset_self, ptagset_other = self.tag_set[1], other.tag_set[1]
-        it = iter(ptagset_self)
         for key_self in ptagset_self:
             if ptagset_other.has(key_self):
                 version_self, version_other = ptagset_self.get(key_self), ptagset_other.get(key_self)
@@ -381,6 +378,7 @@ class ImageRef:
 class DeviceTypes(enum.Enum):
     CPU = 'cpu'
     MEMORY = 'mem'
+
 
 DeviceType = NewType('DeviceType', Union[str, DeviceTypes])
 

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -372,7 +372,7 @@ class ImageRef:
             while True:
                 key_self = next(it, None)
                 if key_self == None: #comparison complete
-                    return len(ptagset_self) - len(ptagset_other)
+                    return len(ptagset_self) > len(ptagset_other)
                 elif ptagset_other.has(key_self):
                     version_self, version_other = ptagset_self.get(key_self), ptagset_other.get(key_self)
                     if version_self and version_other:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -349,6 +349,15 @@ def test_image_ref_ordering():
     with pytest.raises(ValueError):
         r1 < rx
 
+    # test case added for explicit behavior documentation
+    # ImageRef(...:ubuntu16.04) > ImageRef(...:ubuntu) == False
+    # ImageRef(...:ubuntu16.04) > ImageRef(...:ubuntu) == False
+    # by keeping naming convetion, no need to handle these cases
+    r4 = ImageRef('lablup/python-tensorflow:1.5-py36-ubuntu16.04-cuda9.0')
+    r5 = ImageRef('lablup/python-tensorflow:1.5-py36-ubuntu-cuda9.0')
+    assert not r4 > r5
+    assert not r5 > r4
+
 
 def test_image_ref_merge_aliases():
     # After merging, aliases that indicates two or more references should


### PR DESCRIPTION
ImageRef class generate_aliases, merge_aliases methods implemented
both methods return types changed:
`Mapping[str, str]` ====> `Mapping[str, ImageRef]`
`Sequence[str]` =====> `Mapping[str, ImageRef]`