### PR TITLE
Scoped configurations on etcd

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     setproctitle~=1.1.10
     python-json-logger
     packaging
+    trafaret>=1.2.0
 
 [options.packages.find]
 where = src

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -86,13 +86,11 @@ async def login(
 
 
 async def get_known_registries(etcd: AsyncEtcd) -> Mapping[str, yarl.URL]:
-    pairs = await etcd.get_prefix('config/docker/registry/')
+    data = await etcd.get_prefix('config/docker/registry/')
     results = {}
-    for key, value in pairs:
-        parts = key.split('/')
-        if len(parts) == 4:
-            name = etcd_unquote(parts[-1])
-            results[name] = value
+    for key, value in data.items():
+        name = etcd_unquote(key)
+        results[name] = value
     return results
 
 
@@ -113,7 +111,7 @@ def is_known_registry(val: str,
 
 async def get_registry_info(etcd: AsyncEtcd, name: str) -> Tuple[yarl.URL, dict]:
     reg_path = f'config/docker/registry/{etcd_quote(name)}'
-    item = await etcd.get_prefix_dict(reg_path)
+    item = await etcd.get_prefix(reg_path)
     if not item:
         raise UnknownImageRegistry(name)
     registry_addr = item['']

--- a/src/ai/backend/common/etcd.py
+++ b/src/ai/backend/common/etcd.py
@@ -269,9 +269,10 @@ class AsyncEtcd:
         key = self._mangle_key(f'{scope_prefix}/{key}')
         if ready_event:
             ready_event.set()
-        # yield from in async-generator is not supported.
+        scope_prefix_len = len(f'{scope_prefix}/')
+        # NOTE: yield from in async-generator is not supported.
         async for ev in self._watch_impl(key):
-            yield Event(ev.key.lstrip(f'{scope_prefix}/'), ev.event, ev.value)
+            yield Event(ev.key[scope_prefix_len:], ev.event, ev.value)
             if once:
                 break
 
@@ -286,7 +287,8 @@ class AsyncEtcd:
         range_end = etcd3.utils.increment_last_byte(etcd3.utils.to_bytes(key_prefix))
         if ready_event:
             ready_event.set()
+        scope_prefix_len = len(f'{scope_prefix}/')
         async for ev in self._watch_impl(key_prefix, range_end=range_end):
-            yield Event(ev.key.lstrip(f'{scope_prefix}/'), ev.event, ev.value)
+            yield Event(ev.key[scope_prefix_len:], ev.event, ev.value)
             if once:
                 break

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,18 +22,18 @@ def test_ns():
 
 @pytest.fixture
 async def etcd(etcd_addr, test_ns):
-    etcd = AsyncEtcd(addr=etcd_addr, namespace=test_ns, scope_prefixes={
+    etcd = AsyncEtcd(addr=etcd_addr, namespace=test_ns, scope_prefix_map={
         ConfigScopes.GLOBAL: 'global',
         ConfigScopes.SGROUP: 'sgroup/testing',
         ConfigScopes.NODE: 'node/i-test',
     })
     try:
-        await etcd.delete_prefix('', ConfigScopes.GLOBAL)
-        await etcd.delete_prefix('', ConfigScopes.SGROUP)
-        await etcd.delete_prefix('', ConfigScopes.NODE)
+        await etcd.delete_prefix('', scope=ConfigScopes.GLOBAL)
+        await etcd.delete_prefix('', scope=ConfigScopes.SGROUP)
+        await etcd.delete_prefix('', scope=ConfigScopes.NODE)
         yield etcd
     finally:
-        await etcd.delete_prefix('', ConfigScopes.GLOBAL)
-        await etcd.delete_prefix('', ConfigScopes.SGROUP)
-        await etcd.delete_prefix('', ConfigScopes.NODE)
+        await etcd.delete_prefix('', scope=ConfigScopes.GLOBAL)
+        await etcd.delete_prefix('', scope=ConfigScopes.SGROUP)
+        await etcd.delete_prefix('', scope=ConfigScopes.NODE)
         del etcd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def test_ns():
 @pytest.fixture
 async def etcd(etcd_addr, test_ns):
     etcd = AsyncEtcd(addr=etcd_addr, namespace=test_ns, scope_prefixes={
-        ConfigScopes.GLOBAL: 'config',
+        ConfigScopes.GLOBAL: 'global',
         ConfigScopes.SGROUP: 'sgroup/testing',
         ConfigScopes.NODE: 'node/i-test',
     })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,3 +37,18 @@ async def etcd(etcd_addr, test_ns):
         await etcd.delete_prefix('', scope=ConfigScopes.SGROUP)
         await etcd.delete_prefix('', scope=ConfigScopes.NODE)
         del etcd
+
+
+@pytest.fixture
+async def gateway_etcd(etcd_addr, test_ns):
+    etcd = AsyncEtcd(addr=etcd_addr, namespace=test_ns, scope_prefix_map={
+        ConfigScopes.GLOBAL: '',
+        ConfigScopes.SGROUP: 'sgroup/testing',
+        ConfigScopes.NODE: 'node/i-test',
+    })
+    try:
+        await etcd.delete_prefix('', scope=ConfigScopes.GLOBAL)
+        yield etcd
+    finally:
+        await etcd.delete_prefix('', scope=ConfigScopes.GLOBAL)
+        del etcd

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -2,30 +2,78 @@ import asyncio
 
 import pytest
 
+from ai.backend.common.etcd import ConfigScopes
+
 
 @pytest.mark.asyncio
 async def test_basic_crud(etcd):
 
-    await etcd.put('wow', 'abc')
+    await etcd.put('wow', 'abc', ConfigScopes.GLOBAL)
 
     v = await etcd.get('wow')
     assert v == 'abc'
-    v = list(await etcd.get_prefix('wow'))
+    v = await etcd.get_prefix('wow')
     assert len(v) == 1
-    assert v[0] == ('wow', 'abc')
+    assert v == {'': 'abc'}
 
-    r = await etcd.replace('wow', 'aaa', 'ccc')
+    r = await etcd.replace('wow', 'aaa', 'ccc', ConfigScopes.GLOBAL)
     assert r is False
-    r = await etcd.replace('wow', 'abc', 'def')
+    r = await etcd.replace('wow', 'abc', 'def', ConfigScopes.GLOBAL)
     assert r is True
     v = await etcd.get('wow')
     assert v == 'def'
 
-    await etcd.delete('wow')
+    await etcd.delete('wow', ConfigScopes.GLOBAL)
 
     v = await etcd.get('wow')
     assert v is None
-    v = list(await etcd.get_prefix('wow'))
+    v = await etcd.get_prefix('wow')
+    assert len(v) == 0
+
+
+@pytest.mark.asyncio
+async def test_scope(etcd):
+    await etcd.put('wow', 'abc', ConfigScopes.GLOBAL)
+    await etcd.put('wow', 'def', ConfigScopes.SGROUP)
+    await etcd.put('wow', 'ghi', ConfigScopes.NODE)
+    v = await etcd.get('wow')
+    assert v == 'ghi'
+
+    await etcd.delete('wow', ConfigScopes.NODE)
+    v = await etcd.get('wow')
+    assert v == 'def'
+
+    await etcd.delete('wow', ConfigScopes.SGROUP)
+    v = await etcd.get('wow')
+    assert v == 'abc'
+
+    await etcd.delete('wow', ConfigScopes.GLOBAL)
+    v = await etcd.get('wow')
+    assert v is None
+
+    await etcd.put('wow', '000', ConfigScopes.NODE)
+    v = await etcd.get('wow')
+    assert v == '000'
+
+
+@pytest.mark.asyncio
+async def test_scope_dict(etcd):
+    await etcd.put_dict({'point/x': '1', 'point/y': '2'}, ConfigScopes.GLOBAL)
+    await etcd.put_dict({'point/y': '3'}, ConfigScopes.SGROUP)
+    await etcd.put_dict({'point/x': '4'}, ConfigScopes.NODE)
+    v = await etcd.get_prefix('point')
+    assert v == {'x': '4', 'y': '3'}
+
+    await etcd.delete_prefix('point', ConfigScopes.NODE)
+    v = await etcd.get_prefix('point')
+    assert v == {'x': '1', 'y': '3'}
+
+    await etcd.delete_prefix('point', ConfigScopes.SGROUP)
+    v = await etcd.get_prefix('point')
+    assert v == {'x': '1', 'y': '2'}
+
+    await etcd.delete_prefix('point', ConfigScopes.GLOBAL)
+    v = await etcd.get_prefix('point')
     assert len(v) == 0
 
 
@@ -37,13 +85,13 @@ async def test_multi(etcd):
     v = await etcd.get('bar')
     assert v is None
 
-    await etcd.put_multi(['foo', 'bar'], ['x', 'y'])
+    await etcd.put_dict({'foo': 'x', 'bar': 'y'}, ConfigScopes.GLOBAL)
     v = await etcd.get('foo')
     assert v == 'x'
     v = await etcd.get('bar')
     assert v == 'y'
 
-    await etcd.delete_multi(['foo', 'bar'])
+    await etcd.delete_multi(['foo', 'bar'], ConfigScopes.GLOBAL)
     v = await etcd.get('foo')
     assert v is None
     v = await etcd.get('bar')
@@ -60,14 +108,14 @@ async def test_watch(etcd, event_loop):
 
     async def _record():
         try:
-            async for ev in etcd.watch('wow', ready_event=r_ready):
+            async for ev in etcd.watch('wow', ConfigScopes.GLOBAL, ready_event=r_ready):
                 records.append(ev)
         except asyncio.CancelledError:
             pass
 
     async def _record_prefix():
         try:
-            async for ev in etcd.watch_prefix('wow', ready_event=rp_ready):
+            async for ev in etcd.watch_prefix('wow', ConfigScopes.GLOBAL, ready_event=rp_ready):
                 records_prefix.append(ev)
         except asyncio.CancelledError:
             pass
@@ -78,10 +126,10 @@ async def test_watch(etcd, event_loop):
     await r_ready.wait()
     await rp_ready.wait()
 
-    await etcd.put('wow', '123')
-    await etcd.delete('wow')
-    await etcd.put('wow/child', 'hello')
-    await etcd.delete_prefix('wow')
+    await etcd.put('wow', '123', ConfigScopes.GLOBAL)
+    await etcd.delete('wow', ConfigScopes.GLOBAL)
+    await etcd.put('wow/child', 'hello', ConfigScopes.GLOBAL)
+    await etcd.delete_prefix('wow', ConfigScopes.GLOBAL)
 
     await asyncio.sleep(0.2)
     t1.cancel()
@@ -122,14 +170,14 @@ async def test_watch_once(etcd, event_loop):
 
     async def _record():
         try:
-            async for ev in etcd.watch('wow', once=True, ready_event=r_ready):
+            async for ev in etcd.watch('wow', ConfigScopes.GLOBAL, once=True, ready_event=r_ready):
                 records.append(ev)
         except asyncio.CancelledError:
             pass
 
     async def _record_prefix():
         try:
-            async for ev in etcd.watch_prefix('wow/city', once=True, ready_event=rp_ready):
+            async for ev in etcd.watch_prefix('wow/city', ConfigScopes.GLOBAL, once=True, ready_event=rp_ready):
                 records_prefix.append(ev)
         except asyncio.CancelledError:
             pass
@@ -139,10 +187,10 @@ async def test_watch_once(etcd, event_loop):
     await r_ready.wait()
     await rp_ready.wait()
 
-    await etcd.put('wow/city1', 'seoul')
-    await etcd.put('wow/city2', 'daejeon')
-    await etcd.put('wow', 'korea')
-    await etcd.delete_prefix('wow')
+    await etcd.put('wow/city1', 'seoul', ConfigScopes.GLOBAL)
+    await etcd.put('wow/city2', 'daejeon', ConfigScopes.GLOBAL)
+    await etcd.put('wow', 'korea', ConfigScopes.GLOBAL)
+    await etcd.delete_prefix('wow', ConfigScopes.GLOBAL)
 
     await asyncio.sleep(0.2)
     t1.cancel()

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -8,7 +8,7 @@ from ai.backend.common.etcd import ConfigScopes
 @pytest.mark.asyncio
 async def test_basic_crud(etcd):
 
-    await etcd.put('wow', 'abc', ConfigScopes.GLOBAL)
+    await etcd.put('wow', 'abc')
 
     v = await etcd.get('wow')
     assert v == 'abc'
@@ -16,14 +16,14 @@ async def test_basic_crud(etcd):
     assert len(v) == 1
     assert v == {'': 'abc'}
 
-    r = await etcd.replace('wow', 'aaa', 'ccc', ConfigScopes.GLOBAL)
+    r = await etcd.replace('wow', 'aaa', 'ccc')
     assert r is False
-    r = await etcd.replace('wow', 'abc', 'def', ConfigScopes.GLOBAL)
+    r = await etcd.replace('wow', 'abc', 'def')
     assert r is True
     v = await etcd.get('wow')
     assert v == 'def'
 
-    await etcd.delete('wow', ConfigScopes.GLOBAL)
+    await etcd.delete('wow')
 
     v = await etcd.get('wow')
     assert v is None
@@ -33,46 +33,46 @@ async def test_basic_crud(etcd):
 
 @pytest.mark.asyncio
 async def test_scope(etcd):
-    await etcd.put('wow', 'abc', ConfigScopes.GLOBAL)
-    await etcd.put('wow', 'def', ConfigScopes.SGROUP)
-    await etcd.put('wow', 'ghi', ConfigScopes.NODE)
+    await etcd.put('wow', 'abc', scope=ConfigScopes.GLOBAL)
+    await etcd.put('wow', 'def', scope=ConfigScopes.SGROUP)
+    await etcd.put('wow', 'ghi', scope=ConfigScopes.NODE)
     v = await etcd.get('wow')
     assert v == 'ghi'
 
-    await etcd.delete('wow', ConfigScopes.NODE)
+    await etcd.delete('wow', scope=ConfigScopes.NODE)
     v = await etcd.get('wow')
     assert v == 'def'
 
-    await etcd.delete('wow', ConfigScopes.SGROUP)
+    await etcd.delete('wow', scope=ConfigScopes.SGROUP)
     v = await etcd.get('wow')
     assert v == 'abc'
 
-    await etcd.delete('wow', ConfigScopes.GLOBAL)
+    await etcd.delete('wow', scope=ConfigScopes.GLOBAL)
     v = await etcd.get('wow')
     assert v is None
 
-    await etcd.put('wow', '000', ConfigScopes.NODE)
+    await etcd.put('wow', '000', scope=ConfigScopes.NODE)
     v = await etcd.get('wow')
     assert v == '000'
 
 
 @pytest.mark.asyncio
 async def test_scope_dict(etcd):
-    await etcd.put_dict({'point/x': '1', 'point/y': '2'}, ConfigScopes.GLOBAL)
-    await etcd.put_dict({'point/y': '3'}, ConfigScopes.SGROUP)
-    await etcd.put_dict({'point/x': '4'}, ConfigScopes.NODE)
+    await etcd.put_dict({'point/x': '1', 'point/y': '2'}, scope=ConfigScopes.GLOBAL)
+    await etcd.put_dict({'point/y': '3'}, scope=ConfigScopes.SGROUP)
+    await etcd.put_dict({'point/x': '4'}, scope=ConfigScopes.NODE)
     v = await etcd.get_prefix('point')
     assert v == {'x': '4', 'y': '3'}
 
-    await etcd.delete_prefix('point', ConfigScopes.NODE)
+    await etcd.delete_prefix('point', scope=ConfigScopes.NODE)
     v = await etcd.get_prefix('point')
     assert v == {'x': '1', 'y': '3'}
 
-    await etcd.delete_prefix('point', ConfigScopes.SGROUP)
+    await etcd.delete_prefix('point', scope=ConfigScopes.SGROUP)
     v = await etcd.get_prefix('point')
     assert v == {'x': '1', 'y': '2'}
 
-    await etcd.delete_prefix('point', ConfigScopes.GLOBAL)
+    await etcd.delete_prefix('point', scope=ConfigScopes.GLOBAL)
     v = await etcd.get_prefix('point')
     assert len(v) == 0
 
@@ -85,13 +85,13 @@ async def test_multi(etcd):
     v = await etcd.get('bar')
     assert v is None
 
-    await etcd.put_dict({'foo': 'x', 'bar': 'y'}, ConfigScopes.GLOBAL)
+    await etcd.put_dict({'foo': 'x', 'bar': 'y'})
     v = await etcd.get('foo')
     assert v == 'x'
     v = await etcd.get('bar')
     assert v == 'y'
 
-    await etcd.delete_multi(['foo', 'bar'], ConfigScopes.GLOBAL)
+    await etcd.delete_multi(['foo', 'bar'])
     v = await etcd.get('foo')
     assert v is None
     v = await etcd.get('bar')
@@ -108,14 +108,14 @@ async def test_watch(etcd, event_loop):
 
     async def _record():
         try:
-            async for ev in etcd.watch('wow', ConfigScopes.GLOBAL, ready_event=r_ready):
+            async for ev in etcd.watch('wow', ready_event=r_ready):
                 records.append(ev)
         except asyncio.CancelledError:
             pass
 
     async def _record_prefix():
         try:
-            async for ev in etcd.watch_prefix('wow', ConfigScopes.GLOBAL, ready_event=rp_ready):
+            async for ev in etcd.watch_prefix('wow', ready_event=rp_ready):
                 records_prefix.append(ev)
         except asyncio.CancelledError:
             pass
@@ -126,10 +126,10 @@ async def test_watch(etcd, event_loop):
     await r_ready.wait()
     await rp_ready.wait()
 
-    await etcd.put('wow', '123', ConfigScopes.GLOBAL)
-    await etcd.delete('wow', ConfigScopes.GLOBAL)
-    await etcd.put('wow/child', 'hello', ConfigScopes.GLOBAL)
-    await etcd.delete_prefix('wow', ConfigScopes.GLOBAL)
+    await etcd.put('wow', '123')
+    await etcd.delete('wow')
+    await etcd.put('wow/child', 'hello')
+    await etcd.delete_prefix('wow')
 
     await asyncio.sleep(0.2)
     t1.cancel()
@@ -170,14 +170,14 @@ async def test_watch_once(etcd, event_loop):
 
     async def _record():
         try:
-            async for ev in etcd.watch('wow', ConfigScopes.GLOBAL, once=True, ready_event=r_ready):
+            async for ev in etcd.watch('wow', once=True, ready_event=r_ready):
                 records.append(ev)
         except asyncio.CancelledError:
             pass
 
     async def _record_prefix():
         try:
-            async for ev in etcd.watch_prefix('wow/city', ConfigScopes.GLOBAL, once=True, ready_event=rp_ready):
+            async for ev in etcd.watch_prefix('wow/city', once=True, ready_event=rp_ready):
                 records_prefix.append(ev)
         except asyncio.CancelledError:
             pass
@@ -187,10 +187,10 @@ async def test_watch_once(etcd, event_loop):
     await r_ready.wait()
     await rp_ready.wait()
 
-    await etcd.put('wow/city1', 'seoul', ConfigScopes.GLOBAL)
-    await etcd.put('wow/city2', 'daejeon', ConfigScopes.GLOBAL)
-    await etcd.put('wow', 'korea', ConfigScopes.GLOBAL)
-    await etcd.delete_prefix('wow', ConfigScopes.GLOBAL)
+    await etcd.put('wow/city1', 'seoul')
+    await etcd.put('wow/city2', 'daejeon')
+    await etcd.put('wow', 'korea')
+    await etcd.delete_prefix('wow')
 
     await asyncio.sleep(0.2)
     t1.cancel()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -198,15 +198,14 @@ def test_image_ref_formats():
 
 @pytest.mark.asyncio
 async def test_image_ref_resolve(etcd):
-    scope = ConfigScopes.GLOBAL
-    await etcd.put('config/docker/registry/myregistry.org', 'https://myregistry.org', scope)
-    await etcd.put('images/index.docker.io/lablup%2Fpython/3.6', 'abcd', scope)
-    await etcd.put('images/index.docker.io/lablup%2Fpython/3.5', 'abef', scope)
-    await etcd.put('images/myregistry.org/python/3.6-ubuntu', 'eeab', scope)
-    await etcd.put('images/_aliases/python',        'python:latest', scope)
-    await etcd.put('images/_aliases/python:latest', 'lablup/python:3.6', scope)
-    await etcd.put('images/_aliases/mypython',      'myregistry.org/python:3.6', scope)
-    await etcd.put('images/_aliases/infinite-loop', 'infinite-loop', scope)
+    await etcd.put('config/docker/registry/myregistry.org', 'https://myregistry.org')
+    await etcd.put('images/index.docker.io/lablup%2Fpython/3.6', 'abcd')
+    await etcd.put('images/index.docker.io/lablup%2Fpython/3.5', 'abef')
+    await etcd.put('images/myregistry.org/python/3.6-ubuntu', 'eeab')
+    await etcd.put('images/_aliases/python',        'python:latest')
+    await etcd.put('images/_aliases/python:latest', 'lablup/python:3.6')
+    await etcd.put('images/_aliases/mypython',      'myregistry.org/python:3.6')
+    await etcd.put('images/_aliases/infinite-loop', 'infinite-loop')
 
     # single-shot resolution
     ref = await ImageRef.resolve_alias('python:latest', etcd)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -9,6 +9,7 @@ from ai.backend.common.types import (
     BinarySize, ImageRef, PlatformTagSet, ResourceSlot,
     DefaultForUnspecified,
 )
+from ai.backend.common.etcd import ConfigScopes
 
 import pytest
 
@@ -197,14 +198,15 @@ def test_image_ref_formats():
 
 @pytest.mark.asyncio
 async def test_image_ref_resolve(etcd):
-    await etcd.put('config/docker/registry/myregistry.org', 'https://myregistry.org')
-    await etcd.put('images/index.docker.io/lablup%2Fpython/3.6', 'abcd')
-    await etcd.put('images/index.docker.io/lablup%2Fpython/3.5', 'abef')
-    await etcd.put('images/myregistry.org/python/3.6-ubuntu', 'eeab')
-    await etcd.put('images/_aliases/python',        'python:latest')
-    await etcd.put('images/_aliases/python:latest', 'lablup/python:3.6')
-    await etcd.put('images/_aliases/mypython',      'myregistry.org/python:3.6')
-    await etcd.put('images/_aliases/infinite-loop', 'infinite-loop')
+    scope = ConfigScopes.GLOBAL
+    await etcd.put('config/docker/registry/myregistry.org', 'https://myregistry.org', scope)
+    await etcd.put('images/index.docker.io/lablup%2Fpython/3.6', 'abcd', scope)
+    await etcd.put('images/index.docker.io/lablup%2Fpython/3.5', 'abef', scope)
+    await etcd.put('images/myregistry.org/python/3.6-ubuntu', 'eeab', scope)
+    await etcd.put('images/_aliases/python',        'python:latest', scope)
+    await etcd.put('images/_aliases/python:latest', 'lablup/python:3.6', scope)
+    await etcd.put('images/_aliases/mypython',      'myregistry.org/python:3.6', scope)
+    await etcd.put('images/_aliases/infinite-loop', 'infinite-loop', scope)
 
     # single-shot resolution
     ref = await ImageRef.resolve_alias('python:latest', etcd)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -9,7 +9,6 @@ from ai.backend.common.types import (
     BinarySize, ImageRef, PlatformTagSet, ResourceSlot,
     DefaultForUnspecified,
 )
-from ai.backend.common.etcd import ConfigScopes
 
 import pytest
 


### PR DESCRIPTION
Now we want to set global (cluster-level) configs, scaling-group configs, and per-node configs separately and merge them when reading configurations.

Let the manager and the agent provide actual scope prefixes (e.g., per-node prefix requires instance IDs) and the AsyncEtcd instance use them.