### PR TITLE
Add mount_map to type KernelCreationConfig

### DIFF
--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -569,6 +569,7 @@ class KernelCreationConfig(TypedDict):
     resource_opts: Mapping[str, str]   # json form of resource options
     environ: Mapping[str, str]
     mounts: Sequence[str]              # list of mount expressions
+    mount_map: Mapping[str, str]       # Mapping of vfolder custom mount path
     idle_timeout: int
     startup_command: Optional[str]
     internal_data: Optional[Mapping[str, Any]]


### PR DESCRIPTION
This PR is a part of lablup/backend.ai-manager#206 and lablup/backend.ai-agent#155, which adds a `mount_map` parameter to `KernelCreationConfig`. 