### PR TITLE
etcd: Automatically unquote dict keys for get-prefix operation

### DIFF
--- a/src/ai/backend/common/etcd.py
+++ b/src/ai/backend/common/etcd.py
@@ -68,13 +68,14 @@ def make_dict_from_pairs(key_prefix, pairs, path_sep='/'):
         path_components = subkey.split('/')
         parent = result
         for p in path_components[:-1]:
+            p = unquote(p)
             if p not in parent:
                 parent[p] = {}
             if p in parent and not isinstance(parent[p], dict):
                 root = parent[p]
                 parent[p] = {'': root}
             parent = parent[p]
-        parent[path_components[-1]] = v
+        parent[unquote(path_components[-1])] = v
     return result
 
 

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -13,6 +13,7 @@ from typing import (
     Mapping,
     NewType, Type, TypeVar,
     TypedDict,
+    TYPE_CHECKING,
 )
 import uuid
 
@@ -40,6 +41,9 @@ __all__ = (
     'KernelCreationResult',
     'ServicePortProtocols',
 )
+
+if TYPE_CHECKING:
+    from .docker import ImageRef
 
 
 T_aobj = TypeVar('T_aobj', bound='aobject')
@@ -592,7 +596,7 @@ class KernelEnqueueingConfig(TypedDict):
     idx: int
     creation_config: dict
     bootstrap_script: str
-    startup_command: str = None
+    startup_command: str
 
 
 def _stringify_number(v: Union[BinarySize, int, float, Decimal]) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import secrets
 
@@ -37,6 +38,7 @@ async def etcd(etcd_addr, test_ns):
         await etcd.delete_prefix('', scope=ConfigScopes.SGROUP)
         await etcd.delete_prefix('', scope=ConfigScopes.NODE)
         await etcd.close()
+        await asyncio.sleep(0.1)  # we need a grace period to shutdown watch callbacks
         del etcd
 
 

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -32,7 +32,32 @@ async def test_basic_crud(etcd):
 
 
 @pytest.mark.asyncio
-async def test_unquote_for_prefix_dict(etcd):
+async def test_quote_for_put_prefix(etcd):
+    await etcd.put_prefix('data', {
+        'aa:bb': {
+            'option1': 'value1',
+            'option2': 'value2',
+            'myhost/path': 'this',
+        },
+        'aa:cc': 'wow',
+        'aa:dd': {
+            '': 'oops',
+        },
+    }, scope=ConfigScopes.GLOBAL)
+    v = await etcd.get('data/aa%3Abb/option1')
+    assert v == 'value1'
+    v = await etcd.get('data/aa%3Abb/option2')
+    assert v == 'value2'
+    v = await etcd.get('data/aa%3Abb/myhost%2Fpath')
+    assert v == 'this'
+    v = await etcd.get('data/aa%3Acc')
+    assert v == 'wow'
+    v = await etcd.get('data/aa%3Add')
+    assert v == 'oops'
+
+
+@pytest.mark.asyncio
+async def test_unquote_for_get_prefix(etcd):
     await etcd.put('obj/aa%3Abb/option1', 'value1')
     await etcd.put('obj/aa%3Abb/option2', 'value2')
     await etcd.put('obj/aa%3Abb/myhost%2Fpath', 'this')


### PR DESCRIPTION
 * Automatically unquote nested dict keys from `etcd.get_prefix()` to avoid caller mistakes.
 * Add a new method `etcd.put_prefix()` which automatically quotes the given nested dict keys as an analogy.
   - Existing `etcd.put_dict()` method accepts only flattened dicts with already quoted keys.
   - From now on, `etcd.put_prefix()` is the preferred method in new codes.