### PR TITLE
feat: add function to convert humanized timedelta str t timedelta obj

### DIFF
--- a/changes/37.feature
+++ b/changes/37.feature
@@ -1,0 +1,1 @@
+Add function to convert humanized timedelta string to timedelta obj.

--- a/src/ai/backend/common/utils.py
+++ b/src/ai/backend/common/utils.py
@@ -144,6 +144,23 @@ def readable_size_to_bytes(expr):
 
 
 def str_to_timedelta(tstr):
+    """
+    Convert humanized timedelta string into a Python timedelta object.
+
+    Example:
+    >>> str_to_timedelta('30min')
+    datetime.timedelta(seconds=1800)
+    >>> str_to_timedelta('1d1hr')
+    datetime.timedelta(days=1, seconds=3600)
+    >>> str_to_timedelta('2hours 15min')
+    datetime.timedelta(seconds=8100)
+    >>> str_to_timedelta('20sec')
+    datetime.timedelta(seconds=20)
+    >>> str_to_timedelta('300')
+    datetime.timedelta(seconds=300)
+    >>> str_to_timedelta('-1day')
+    datetime.timedelta(days=-1)
+    """
     _rx = re.compile(r'(?P<sign>[+|-])?\s*'
                      r'((?P<days>\d+(\.\d+)?)(d|day|days))?\s*'
                      r'((?P<hours>\d+(\.\d+)?)(h|hr|hrs|hour|hours))?\s*'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import codecs
 from collections import OrderedDict
+from datetime import timedelta
 from pathlib import Path
 from random import choice
 from string import ascii_uppercase
@@ -14,6 +15,7 @@ from ai.backend.common.utils import (
     odict, dict2kvlist, nmget,
     generate_uuid, get_random_seq,
     readable_size_to_bytes,
+    str_to_timedelta,
     current_loop, curl,
     run_through,
     StringSetFlag,
@@ -89,6 +91,42 @@ def test_readable_size_to_bytes():
         readable_size_to_bytes('3A')
     with pytest.raises(ValueError):
         readable_size_to_bytes('TT')
+
+
+def test_str_to_timedelta():
+    assert str_to_timedelta('1d2h3m4s') == timedelta(days=1, hours=2, minutes=3, seconds=4)
+    assert str_to_timedelta('1d2h3m') == timedelta(days=1, hours=2, minutes=3)
+    assert str_to_timedelta('1d2h') == timedelta(days=1, hours=2)
+    assert str_to_timedelta('1d') == timedelta(days=1)
+    assert str_to_timedelta('2h3m4s') == timedelta(hours=2, minutes=3, seconds=4)
+    assert str_to_timedelta('2h3m') == timedelta(hours=2, minutes=3)
+    assert str_to_timedelta('2h') == timedelta(hours=2)
+    assert str_to_timedelta('3m4s') == timedelta(minutes=3, seconds=4)
+    assert str_to_timedelta('3m') == timedelta(minutes=3)
+    assert str_to_timedelta('4s') == timedelta(seconds=4)
+    assert str_to_timedelta('4') == timedelta(seconds=4)
+
+    assert str_to_timedelta('1days2hr') == timedelta(days=1, hours=2)
+
+    assert str_to_timedelta('+1d2h3m4s') == timedelta(days=1, hours=2, minutes=3, seconds=4)
+    assert str_to_timedelta('-1d2h3m4s') == timedelta(days=-1, hours=-2, minutes=-3, seconds=-4)
+    assert str_to_timedelta('1day2hr3min4sec') == timedelta(days=1, hours=2, minutes=3, seconds=4)
+    assert str_to_timedelta('1day2hour3minute4second') == timedelta(days=1, hours=2, minutes=3, seconds=4)
+    assert str_to_timedelta('1day 2hour 3minute 4second') == timedelta(days=1, hours=2, minutes=3, seconds=4)
+    assert str_to_timedelta('1days 2hours 3minutes 4seconds') == timedelta(days=1, hours=2, minutes=3, seconds=4)
+    assert str_to_timedelta('0.1d0.2h0.3m0.4s') == timedelta(days=.1, hours=.2, minutes=.3, seconds=.4)
+    assert str_to_timedelta('1d 2h 3m 4s') == timedelta(days=1, hours=2, minutes=3, seconds=4)
+    assert str_to_timedelta('-1d 2h 3m 4s') == timedelta(days=-1, hours=-2, minutes=-3, seconds=-4)
+    assert str_to_timedelta('- 1d 2h 3m 4s') == timedelta(days=-1, hours=-2, minutes=-3, seconds=-4)
+
+    with pytest.raises(ValueError):
+        assert str_to_timedelta('1da1hr')
+    with pytest.raises(ValueError):
+        assert str_to_timedelta('--1d2h3m4s')
+    with pytest.raises(ValueError):
+        assert str_to_timedelta('+')
+    with pytest.raises(ValueError):
+        assert str_to_timedelta('')
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,8 +106,6 @@ def test_str_to_timedelta():
     assert str_to_timedelta('4s') == timedelta(seconds=4)
     assert str_to_timedelta('4') == timedelta(seconds=4)
 
-    assert str_to_timedelta('1days2hr') == timedelta(days=1, hours=2)
-
     assert str_to_timedelta('+1d2h3m4s') == timedelta(days=1, hours=2, minutes=3, seconds=4)
     assert str_to_timedelta('-1d2h3m4s') == timedelta(days=-1, hours=-2, minutes=-3, seconds=-4)
     assert str_to_timedelta('1day2hr3min4sec') == timedelta(days=1, hours=2, minutes=3, seconds=4)


### PR DESCRIPTION
This PR introduces a function which convert humanized timedelta string into a Python's `timedelta` object.

For example,
```python
>>> str_to_timedelta('30min')
datetime.timedelta(seconds=1800)
>>> str_to_timedelta('1d1hr')
datetime.timedelta(days=1, seconds=3600)
>>> str_to_timedelta('2hours 15min')
datetime.timedelta(seconds=8100)
>>> str_to_timedelta('20sec')
datetime.timedelta(seconds=20)
>>> str_to_timedelta('300')
datetime.timedelta(seconds=300)
>>> str_to_timedelta('-1day')
datetime.timedelta(days=-1)
```

Related: lablup/backend.ai#130, OP#101