### PR TITLE
Shared plugin configs for multi-group plugins

### DIFF
--- a/src/ai/backend/common/plugin/__init__.py
+++ b/src/ai/backend/common/plugin/__init__.py
@@ -138,9 +138,10 @@ class BasePluginContext(Generic[P]):
     async def init(self) -> None:
         hook_plugins = self.discover_plugins(self.plugin_group)
         for plugin_name, plugin_entry in hook_plugins:
-            plugin_config = await self.etcd.get_prefix(
-                f"config/plugins/{self._group_key}/{plugin_name}/"
-            )
+            plugin_config = {
+                **(await self.etcd.get_prefix(f"config/plugins/_/{plugin_name}/")),
+                **(await self.etcd.get_prefix(f"config/plugins/{self._group_key}/{plugin_name}/")),
+            }
             try:
                 plugin_instance = plugin_entry(plugin_config, self.local_config)
                 await plugin_instance.init()


### PR DESCRIPTION
This PR makes it possible to use "config/plugins/_/<entrypoint-name>" as the place for shared
configs for multi-group plugins (e.g., plugins that have both hook and webapp plugins).

* [x] Read and merge configs from the shared location and group-sepcific location
* [ ] Unify the watcher to monitor the prefix changes and dispatch the changes to plugins
