### PR TITLE
Fix error monitor plugin default value to None

### DIFF
--- a/src/ai/backend/common/plugin/monitor.py
+++ b/src/ai/backend/common/plugin/monitor.py
@@ -43,7 +43,7 @@ class AbstractStatReporterPlugin(AbstractPlugin, metaclass=ABCMeta):
         metric_type: StatMetricTypes,
         metric_name: str,
         value: Union[float, int] = None,
-    ):
+    ) -> None:
         pass
 
 
@@ -75,7 +75,7 @@ class StatsPluginContext(BasePluginContext[AbstractStatReporterPlugin]):
         metric_type: StatMetricTypes,
         metric_name: str,
         value: Union[float, int] = None,
-    ):
+    ) -> None:
         for plugin_instance in self.plugins.values():
             await plugin_instance.report_metric(metric_type, metric_name, value)
 

--- a/src/ai/backend/common/plugin/monitor.py
+++ b/src/ai/backend/common/plugin/monitor.py
@@ -31,7 +31,7 @@ GAUGE = StatMetricTypes.GAUGE
 
 class AbstractStatReporterPlugin(AbstractPlugin, metaclass=ABCMeta):
 
-    async def init(self, context: Any = {}) -> None:
+    async def init(self, context: Any = None) -> None:
         pass
 
     async def cleanup(self) -> None:
@@ -48,7 +48,7 @@ class AbstractStatReporterPlugin(AbstractPlugin, metaclass=ABCMeta):
 
 
 class AbstractErrorReporterPlugin(AbstractPlugin, metaclass=ABCMeta):
-    async def init(self, context: Any = {}) -> None:
+    async def init(self, context: Any = None) -> None:
         pass
 
     async def cleanup(self) -> None:


### PR DESCRIPTION
- Change default value from {} to None.
- Fix of an error not caught in the previous PR.