### PR TITLE
Add support for unique resource slots

### DIFF
--- a/changes/63.feature
+++ b/changes/63.feature
@@ -1,0 +1,1 @@
+Add `SlotTypes.UNIQUE` declaration

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -123,6 +123,7 @@ SecretKey = NewType('SecretKey', str)
 class SlotTypes(str, enum.Enum):
     COUNT = 'count'
     BYTES = 'bytes'
+    UNIQUE = 'unique'
 
 
 class AutoPullBehavior(str, enum.Enum):


### PR DESCRIPTION
This is for MIG support with the brand new NVIDIA DGX-A100 nodes.
The unique resource slot only allows the unique assignment of a single resource "1.0" to individual container.