### PR TITLE
test: Stabilize tests using a single redis container as fixture

### DIFF
--- a/changes/91.fix
+++ b/changes/91.fix
@@ -1,0 +1,1 @@
+Improve stability of test cases using a single Redis container as fixture (a follow-up to #88)

--- a/tests/redis/conftest.py
+++ b/tests/redis/conftest.py
@@ -27,6 +27,7 @@ async def redis_container(test_ns, test_case_ns) -> AsyncIterator[str]:
     stdout = await p.stdout.read()
     await p.wait()
     cid = stdout.decode().strip()
+    await wait_redis_ready('127.0.0.1', 9379)
     try:
         yield cid
     finally:


### PR DESCRIPTION
This is a follow-up to #88.
