### PR TITLE
feat: Update TimeDuration to support years and months

### DIFF
--- a/changes/99.feature
+++ b/changes/99.feature
@@ -1,1 +1,1 @@
-Update TimeDuration class to support years and months argument
+Update `validators.TimeDuration` class to support years and months

--- a/changes/99.feature
+++ b/changes/99.feature
@@ -1,0 +1,1 @@
+Update TimeDuration class to support years and months argument

--- a/src/ai/backend/common/validators.py
+++ b/src/ai/backend/common/validators.py
@@ -466,20 +466,20 @@ class TimeDuration(t.Trafaret):
     def __init__(self, *, allow_negative: bool = False) -> None:
         self._allow_negative = allow_negative
 
-    def check_and_return(self, value: Any) -> datetime.timedelta:
+    def check_and_return(self, value: Any) -> Union[datetime.timedelta, relativedelta]:
         if not isinstance(value, str):
             self._failure('value must be string', value=value)
         if len(value) == 0:
             self._failure('value must not be empty', value=value)
         try:
-            unit = value[-2:]
+            unit = value[-1]
             if unit.isdigit():
                 t = float(value)
                 if not self._allow_negative and t < 0:
                     self._failure('value must be positive', value=value)
                 return datetime.timedelta(seconds=t)
-            elif unit.isalpha():
-                t = float(value[:-2])
+            elif value[-2:].isalpha():
+                t = int(value[:-2])
                 if value[-2:] == 'yr':
                     return relativedelta(years=t)
                 elif value[-2:] == 'mo':

--- a/src/ai/backend/common/validators.py
+++ b/src/ai/backend/common/validators.py
@@ -462,7 +462,22 @@ class TimeZone(t.Trafaret):
 
 
 class TimeDuration(t.Trafaret):
+    '''
+    Represent the difference between two datetime objects.
 
+    You can calculate years and months considering leap year.
+
+    Example:
+    >>> t = datetime(2020, 2, 29)
+    >>> t + check_and_return(years=1)
+    datetime.datetime(2021, 2, 28, 0, 0)
+    >>> t + check_and_return(years=2)
+    datetime.datetime(2022, 2, 28, 0, 0)
+    >>> t + check_and_return(years=3)
+    datetime.datetime(2023, 2, 28, 0, 0)
+    >>> t + check_and_return(years=4)
+    datetime.datetime(2024, 2, 29, 0, 0) # leap year
+    '''
     def __init__(self, *, allow_negative: bool = False) -> None:
         self._allow_negative = allow_negative
 
@@ -480,6 +495,8 @@ class TimeDuration(t.Trafaret):
                 return datetime.timedelta(seconds=t)
             elif value[-2:].isalpha():
                 t = int(value[:-2])
+                if not self._allow_negative and t < 0:
+                    self._failure('value must be positive', value=value)
                 if value[-2:] == 'yr':
                     return relativedelta(years=t)
                 elif value[-2:] == 'mo':

--- a/src/ai/backend/common/validators.py
+++ b/src/ai/backend/common/validators.py
@@ -29,6 +29,7 @@ import uuid
 import pwd
 
 import dateutil.tz
+from dateutil.relativedelta import relativedelta
 try:
     import jwt
     jwt_available = True
@@ -471,12 +472,20 @@ class TimeDuration(t.Trafaret):
         if len(value) == 0:
             self._failure('value must not be empty', value=value)
         try:
-            unit = value[-1]
+            unit = value[-2:]
             if unit.isdigit():
                 t = float(value)
                 if not self._allow_negative and t < 0:
                     self._failure('value must be positive', value=value)
                 return datetime.timedelta(seconds=t)
+            elif unit.isalpha():
+                t = float(value[:-2])
+                if value[-2:] == 'yr':
+                    return relativedelta(years=t)
+                elif value[-2:] == 'mo':
+                    return relativedelta(months=t)
+                else:
+                    self._failure('value is not a known time duration', value=value)
             else:
                 t = float(value[:-1])
                 if not self._allow_negative and t < 0:

--- a/src/ai/backend/common/validators.py
+++ b/src/ai/backend/common/validators.py
@@ -463,9 +463,16 @@ class TimeZone(t.Trafaret):
 
 class TimeDuration(t.Trafaret):
     '''
-    Represent the difference between two datetime objects.
+    Represent the relative difference between two datetime objects,
+    parsed from human-readable time duration expression strings.
 
-    You can calculate years and months considering leap year.
+    If you specify years or months, it returns an
+    :class:`dateutil.relativedelta.relativedelta` instance
+    which keeps the human-friendly year and month calculation
+    considering leap years and monthly day count differences,
+    instead of simply multiplying 365 days to the value of years.
+    Otherwise, it returns the stdlib's :class:`datetime.timedelta`
+    instance.
 
     Example:
     >>> t = datetime(2020, 2, 29)
@@ -476,7 +483,7 @@ class TimeDuration(t.Trafaret):
     >>> t + check_and_return(years=3)
     datetime.datetime(2023, 2, 28, 0, 0)
     >>> t + check_and_return(years=4)
-    datetime.datetime(2024, 2, 29, 0, 0) # leap year
+    datetime.datetime(2024, 2, 29, 0, 0)  # preserves the same day of month
     '''
     def __init__(self, *, allow_negative: bool = False) -> None:
         self._allow_negative = allow_negative

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,12 +1,10 @@
-from ipaddress import IPv4Address
-
 from datetime import datetime, timedelta
-from dateutil.relativedelta import relativedelta
 import enum
-import ipaddress
+from ipaddress import IPv4Address, ip_address
 import multidict
 import pickle
 
+from dateutil.relativedelta import relativedelta
 import pytest
 import trafaret as t
 import yarl
@@ -188,7 +186,7 @@ def test_delimiter_list():
     assert iv.check('xxx') == ['xxx']
     iv = tx.DelimiterSeperatedList(tx.HostPortPair, delimiter=',')
     assert iv.check('127.0.0.1:6379,127.0.0.1:6380') == \
-        [(ipaddress.ip_address('127.0.0.1'), 6379), (ipaddress.ip_address('127.0.0.1'), 6380)]
+        [(ip_address('127.0.0.1'), 6379), (ip_address('127.0.0.1'), 6380)]
 
 
 def test_string_list():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,7 @@
 from ipaddress import IPv4Address
 
-from datetime import timedelta
+from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
 import enum
 import ipaddress
 import multidict
@@ -394,6 +395,7 @@ def test_json_string():
 
 def test_time_duration():
     iv = tx.TimeDuration()
+    date = datetime(2020, 2, 29)
     with pytest.raises(t.DataError):
         iv.check('')
     assert iv.check('1w') == timedelta(weeks=1)
@@ -404,6 +406,9 @@ def test_time_duration():
     assert iv.check('1') == timedelta(seconds=1)
     assert iv.check('0.5h') == timedelta(minutes=30)
     assert iv.check('0.001') == timedelta(milliseconds=1)
+    assert iv.check('1yr') == relativedelta(years=1)
+    assert iv.check('1mo') == relativedelta(months=1)
+    assert date + iv.check('4yr') == date + relativedelta(years=4)
     with pytest.raises(t.DataError):
         iv.check('-1')
     with pytest.raises(t.DataError):
@@ -420,6 +425,8 @@ def test_time_duration_negative():
     assert iv.check('0.001') == timedelta(milliseconds=1)
     assert iv.check('-1') == timedelta(seconds=-1)
     assert iv.check('-3d') == timedelta(days=-3)
+    assert iv.check('-1yr') == relativedelta(years=-1)
+    assert iv.check('-1mo') == relativedelta(months=-1)
     with pytest.raises(t.DataError):
         iv.check('-a')
     with pytest.raises(t.DataError):


### PR DESCRIPTION
Related PR comment : https://github.com/lablup/backend.ai-manager/pull/498#discussion_r756821898

This will support months and years arguments in TimeDuration class.

* `ai.backend.common.validators.TimeDuration` now support second, weeks, days, hours, minutes arguments.
* "clear_history" function for `mgr clear-history` cli command receives data retention limit as an argument(e.g., 20d, 1mo, 6mo, 1yr') and calculates the expiration date using TimeDuration class.
```
from ai.backend.common.validators import TimeDuration

duration = TimeDuration()
expiration_date = today - duration.check_and_return(retention)
```
* When argument is a value such as "1yr" or "6mo", the function can't calculate using TimeDuration.