### PR TITLE
fix: Import and update `EventDispatcher` test cases from the manager

### DIFF
--- a/changes/112.fix.md
+++ b/changes/112.fix.md
@@ -1,0 +1,1 @@
+Import and update `EventDispatcher` test cases from the manager sources with a minor refactoring to add new optional constructor arguments for custom exception handlers

--- a/tests/redis/conftest.py
+++ b/tests/redis/conftest.py
@@ -11,29 +11,10 @@ import pytest
 from .types import RedisClusterInfo
 from .docker import DockerComposeRedisSentinelCluster
 from .native import NativeRedisSentinelCluster
-from .utils import simple_run_cmd, wait_redis_ready
+from .utils import wait_redis_ready
 
 
-@pytest.fixture
-async def redis_container(test_ns, test_case_ns) -> AsyncIterator[str]:
-    p = await asyncio.create_subprocess_exec(*[
-        'docker', 'run',
-        '-d',
-        '--name', f'bai-common.{test_ns}.{test_case_ns}',
-        '-p', '9379:6379',
-        'redis:6-alpine',
-    ], stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL)
-    assert p.stdout is not None
-    stdout = await p.stdout.read()
-    await p.wait()
-    cid = stdout.decode().strip()
-    await wait_redis_ready('127.0.0.1', 9379)
-    try:
-        yield cid
-    finally:
-        await asyncio.sleep(0.2)
-        await simple_run_cmd(['docker', 'rm', '-f', cid])
-        await asyncio.sleep(0.2)
+# A simple "redis_container" fixture is defined in the main conftest.py
 
 
 @pytest.fixture

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,13 +1,122 @@
 import asyncio
-import pytest
 
 import aiotools
+import attr
+import pytest
 
-from ai.backend.common.events import CoalescingOptions, CoalescingState
+from ai.backend.common.events import (
+    AbstractEvent,
+    CoalescingOptions,
+    CoalescingState,
+    EventDispatcher,
+    EventProducer,
+)
+from ai.backend.common.types import (
+    AgentId,
+    EtcdRedisConfig,
+    HostPortPair,
+)
+from ai.backend.common import redis
+
+
+@attr.s(slots=True, frozen=True)
+class DummyEvent(AbstractEvent):
+    name = "testing"
+
+    value: int = attr.ib()
+
+    def serialize(self) -> tuple:
+        return (self.value + 1, )
+
+    @classmethod
+    def deserialize(cls, value: tuple):
+        return cls(value[0] + 1)
 
 
 @pytest.mark.asyncio
-async def test_rate_control():
+async def test_dispatch(redis_container) -> None:
+    app = object()
+
+    redis_config = EtcdRedisConfig(addr=HostPortPair("127.0.0.1", 9379))
+    dispatcher = await EventDispatcher.new(redis_config)
+    producer = await EventProducer.new(redis_config)
+
+    records = set()
+
+    async def acb(context: object, source: AgentId, event: DummyEvent) -> None:
+        assert context is app
+        assert source == AgentId('i-test')
+        assert isinstance(event, DummyEvent)
+        assert event.name == "testing"
+        assert event.value == 1001
+        await asyncio.sleep(0.01)
+        records.add('async')
+
+    def scb(context: object, source: AgentId, event: DummyEvent) -> None:
+        assert context is app
+        assert source == AgentId('i-test')
+        assert isinstance(event, DummyEvent)
+        assert event.name == "testing"
+        assert event.value == 1001
+        records.add('sync')
+
+    dispatcher.subscribe(DummyEvent, app, acb)
+    dispatcher.subscribe(DummyEvent, app, scb)
+
+    # Dispatch the event
+    await producer.produce_event(DummyEvent(999), source='i-test')
+    await asyncio.sleep(0.2)
+    assert records == {'async', 'sync'}
+
+    await redis.execute(producer.redis_client, lambda r: r.flushdb())
+    await producer.close()
+    await dispatcher.close()
+
+
+@pytest.mark.asyncio
+async def test_error_on_dispatch(redis_container) -> None:
+    app = object()
+    exception_log: list[str] = []
+
+    async def handle_exception(exc: Exception) -> None:
+        exception_log.append(type(exc).__name__)
+
+    redis_config = EtcdRedisConfig(addr=HostPortPair("127.0.0.1", 9379))
+    dispatcher = await EventDispatcher.new(
+        redis_config,
+        consumer_exception_handler=handle_exception,
+        subscriber_exception_handler=handle_exception,
+    )
+    producer = await EventProducer.new(redis_config)
+
+    async def acb(context: object, source: AgentId, event: DummyEvent) -> None:
+        assert context is app
+        assert source == AgentId('i-test')
+        assert isinstance(event, DummyEvent)
+        raise ZeroDivisionError
+
+    def scb(context: object, source: AgentId, event: DummyEvent) -> None:
+        assert context is app
+        assert source == AgentId('i-test')
+        assert isinstance(event, DummyEvent)
+        raise OverflowError
+
+    dispatcher.subscribe(DummyEvent, app, scb)
+    dispatcher.subscribe(DummyEvent, app, acb)
+
+    await producer.produce_event(DummyEvent(0), source='i-test')
+    await asyncio.sleep(0.5)
+    assert len(exception_log) == 2
+    assert 'ZeroDivisionError' in exception_log
+    assert 'OverflowError' in exception_log
+
+    await redis.execute(producer.redis_client, lambda r: r.flushdb())
+    await producer.close()
+    await dispatcher.close()
+
+
+@pytest.mark.asyncio
+async def test_event_dispatcher_rate_control():
     opts = CoalescingOptions(max_wait=0.1, max_batch_size=5)
     state = CoalescingState()
     assert await state.rate_control(None) is True


### PR DESCRIPTION
* Allow users to customize consumer/subscriber exception handlers
  when creating `EventDispatcher` objects.
* Directly call synchronous event handlers instead of using `loop.call_soon()`
  to take advantage of the underlying exception handling mechanism of
  `PersistentTaskGroup`.
