### PR TITLE
feat: Add a Redis pipeline test case as an example

### DIFF
--- a/changes/113.misc.md
+++ b/changes/113.misc.md
@@ -1,0 +1,1 @@
+Add a test case about using Redis pipelines with `types.RedisConnectionInfo` and `redis.execute()` as an example

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -29,6 +29,7 @@ from typing import (
 )
 import uuid
 import aioredis
+import aioredis.client
 import aioredis.sentinel
 import attr
 

--- a/tests/redis/test_pipeline.py
+++ b/tests/redis/test_pipeline.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-
 import aioredis
 import aioredis.client
 import aioredis.sentinel

--- a/tests/redis/test_pipeline.py
+++ b/tests/redis/test_pipeline.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+
+import aioredis
+import aioredis.client
+import aioredis.sentinel
+import pytest
+
+from ai.backend.common.redis import execute
+from ai.backend.common.types import RedisConnectionInfo
+
+from .types import RedisClusterInfo
+
+
+@pytest.mark.asyncio
+async def test_pipeline_single_instance(redis_container: str) -> None:
+    rconn = RedisConnectionInfo(
+        aioredis.from_url(url='redis://localhost:9379', socket_timeout=0.5),
+        service_name=None,
+    )
+
+    def _build_pipeline(r: aioredis.Redis) -> aioredis.client.Pipeline:
+        pipe = r.pipeline()
+        pipe.set("xyz", "123")
+        pipe.incr("xyz")
+        return pipe
+
+    results = await execute(rconn, _build_pipeline)
+    assert results[0] is True
+    assert str(results[1]) == "124"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_sentinel_cluster(redis_cluster: RedisClusterInfo) -> None:
+    rconn = RedisConnectionInfo(
+        aioredis.sentinel.Sentinel(
+            redis_cluster.sentinel_addrs,
+            password='develove',
+            socket_timeout=0.5,
+        ),
+        service_name='mymaster',
+    )
+
+    def _build_pipeline(r: aioredis.Redis) -> aioredis.client.Pipeline:
+        pipe = r.pipeline()
+        pipe.set("xyz", "123")
+        pipe.incr("xyz")
+        return pipe
+
+    results = await execute(rconn, _build_pipeline)
+    assert results[0] is True
+    assert str(results[1]) == "124"


### PR DESCRIPTION
This does not add any new feature or fix bugs, but exemplify how to use Redis pipelines with our `RedisConnectinInfo` connection wrapper and the `redis.execute()` helper function.