### PR TITLE
fix: Generalize error message pattern matching for pipelines

### DIFF
--- a/changes/115.fix.md
+++ b/changes/115.fix.md
@@ -1,0 +1,1 @@
+Improve the retry condition check for Redis command execution failures when used with pipelines

--- a/src/ai/backend/common/redis.py
+++ b/src/ai/backend/common/redis.py
@@ -257,7 +257,7 @@ async def execute(
             await asyncio.sleep(reconnect_poll_interval)
             continue
         except aioredis.exceptions.ResponseError as e:
-            if e.args[0].startswith("NOREPLICAS "):
+            if "NOREPLICAS" in e.args[0]:
                 await asyncio.sleep(reconnect_poll_interval)
                 continue
             raise


### PR DESCRIPTION
resolves lablup/backend.ai#355

* If pipelines are used, the error code may not come in the beginning of
  `e.args[0]` but later in the message due to wrapping of underlying
  exceptions in aioredis.

  e.g., "Command # 1 (SET xyz 123) of pipeline caused error: ('NOREPLICAS Not enough good replicas to write.',)"
