### PR TITLE
fix: Argument typing of `redis.execute_script()`

### DIFF
--- a/changes/126.fix.md
+++ b/changes/126.fix.md
@@ -1,0 +1,1 @@
+Fix argument typing of `redis.execute_script()`

--- a/src/ai/backend/common/redis.py
+++ b/src/ai/backend/common/redis.py
@@ -275,7 +275,7 @@ async def execute_script(
     script_id: str,
     script: str,
     keys: Sequence[str],
-    args: Sequence[Union[str, int, float]],
+    args: Sequence[Union[bytes, memoryview, str, int, float]],  # aioredis.connection.EncodableT
 ) -> Any:
     """
     Auto-load and execute the given script.

--- a/src/ai/backend/common/redis.py
+++ b/src/ai/backend/common/redis.py
@@ -14,6 +14,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Union,
 )
 
 import aioredis
@@ -274,7 +275,7 @@ async def execute_script(
     script_id: str,
     script: str,
     keys: Sequence[str],
-    args: Sequence[str],
+    args: Sequence[Union[str, int, float]],
 ) -> Any:
     """
     Auto-load and execute the given script.


### PR DESCRIPTION
- fix: typing of redis.execute_script()
- fix: make it more precise
