### PR TITLE
refactor: remove unused codes in `ImageRef` class

### DIFF
--- a/changes/127.misc
+++ b/changes/127.misc
@@ -1,0 +1,1 @@
+Remove old codes in ImageRef class, which was used to perform Etcd operations.


### PR DESCRIPTION
This PR removes old codes in `ImageRef` class, which was used to perform Etcd operations when we used Etcd as our image metadata storage.