### PR TITLE
feat: Accept numbers as well in validators.TimeDuration

### DIFF
--- a/changes/128.feature.md
+++ b/changes/128.feature.md
@@ -1,0 +1,1 @@
+Let `validators.TimeDuration` to accept numbers (int and float) as well

--- a/src/ai/backend/common/validators.py
+++ b/src/ai/backend/common/validators.py
@@ -490,8 +490,11 @@ class TimeDuration(t.Trafaret):
         self._allow_negative = allow_negative
 
     def check_and_return(self, value: Any) -> Union[datetime.timedelta, relativedelta]:
-        if not isinstance(value, str):
-            self._failure('value must be string', value=value)
+        if not isinstance(value, (int, float, str)):
+            self._failure('value must be a number or string', value=value)
+        if isinstance(value, (int, float)):
+            return datetime.timedelta(seconds=value)
+        assert isinstance(value, str)
         if len(value) == 0:
             self._failure('value must not be empty', value=value)
         try:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -420,6 +420,9 @@ def test_time_duration():
     date = datetime(2020, 2, 29)
     with pytest.raises(t.DataError):
         iv.check('')
+    assert iv.check(0) == timedelta(seconds=0)
+    assert iv.check(10) == timedelta(seconds=10)
+    assert iv.check(86400.55) == timedelta(days=1, microseconds=550000)
     assert iv.check('1w') == timedelta(weeks=1)
     assert iv.check('1d') == timedelta(days=1)
     assert iv.check('0.5d') == timedelta(hours=12)


### PR DESCRIPTION
We can just pass int or float directly to `timedelta` and it will automatically normalize them as days, seconds, and microseconds.