### PR TITLE
Migrate from aioredis to redis.asyncio

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,8 @@ install_requires =
     pyzmq>=22.1.0
     aiohttp>=3.8.0
     aiodns>=3.0
-    aioredis[hiredis]~=2.0.1
+    redis~=4.2.1
+    hiredis~=2.0
     aiotools>=1.5.5
     async-timeout~=4.0.1
     asyncudp>=0.4
@@ -87,8 +88,9 @@ lint =
 typecheck =
     mypy>=0.942
     types-python-dateutil
-    types-toml
+    types-redis
     types-setuptools
+    types-toml
 dev =
 monitor =
     backend.ai-monitor-sentry>=0.2.1

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -36,7 +36,7 @@ from aiotools.server import process_index
 from aiotools.taskgroup import PersistentTaskGroup
 import attr
 
-from . import msgpack, redis
+from . import msgpack, redis_helper
 from .logging import BraceStyleAdapter
 from .types import (
     EtcdRedisConfig,
@@ -650,7 +650,7 @@ class EventDispatcher(aobject):
         _redis_config = redis_config.copy()
         if service_name:
             _redis_config['service_name'] = service_name
-        self.redis_client = redis.get_redis_object(_redis_config, db=db)
+        self.redis_client = redis_helper.get_redis_object(_redis_config, db=db)
         self._log_events = log_events
         self._closed = False
         self.consumers = defaultdict(set)
@@ -778,7 +778,7 @@ class EventDispatcher(aobject):
             await asyncio.sleep(0)
 
     async def _consume_loop(self) -> None:
-        async with aclosing(redis.read_stream_by_group(
+        async with aclosing(redis_helper.read_stream_by_group(
             self.redis_client,
             self._stream_key,
             self._consumer_group,
@@ -801,7 +801,7 @@ class EventDispatcher(aobject):
                     log.exception('EventDispatcher.consume(): unexpected-error')
 
     async def _subscribe_loop(self) -> None:
-        async with aclosing(redis.read_stream(
+        async with aclosing(redis_helper.read_stream(
             self.redis_client,
             self._stream_key,
         )) as agen:
@@ -839,7 +839,7 @@ class EventProducer(aobject):
         if service_name:
             _redis_config['service_name'] = service_name
         self._closed = False
-        self.redis_client = redis.get_redis_object(_redis_config, db=db)
+        self.redis_client = redis_helper.get_redis_object(_redis_config, db=db)
         self._log_events = log_events
         self._stream_key = stream_key
 
@@ -863,7 +863,7 @@ class EventProducer(aobject):
             b'source': source.encode(),
             b'args': msgpack.packb(event.serialize()),
         }
-        await redis.execute(
+        await redis_helper.execute(
             self.redis_client,
             lambda r: r.xadd(self._stream_key, raw_event),  # type: ignore # aio-libs/aioredis-py#1182
         )

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -31,9 +31,9 @@ from typing import (
 )
 import uuid
 
-import aioredis
-import aioredis.client
-import aioredis.sentinel
+import redis.asyncio
+import redis.asyncio.client
+import redis.asyncio.sentinel
 import attr
 import trafaret as t
 import typeguard
@@ -840,9 +840,9 @@ class EtcdRedisConfig(TypedDict, total=False):
 
 @attr.s(auto_attribs=True)
 class RedisConnectionInfo:
-    client: aioredis.Redis | aioredis.sentinel.Sentinel
+    client: redis.asyncio.Redis | redis.asyncio.Sentinel
     service_name: Optional[str]
 
     async def close(self) -> None:
-        if isinstance(self.client, aioredis.Redis):
+        if isinstance(self.client, redis.asyncio.Redis):
             await self.client.close()

--- a/tests/redis/test_list.py
+++ b/tests/redis/test_list.py
@@ -5,14 +5,13 @@ from typing import (
     List,
 )
 
-import aioredis
-import aioredis.client
-import aioredis.exceptions
-import aioredis.sentinel
+import redis.asyncio
+import redis.asyncio.client
+import redis.exceptions
 import aiotools
 import pytest
 
-from ai.backend.common import redis
+from ai.backend.common import redis_helper
 from ai.backend.common.types import RedisConnectionInfo
 
 from .docker import DockerRedisNode
@@ -34,7 +33,7 @@ async def test_blist(redis_container: str, disruption_method: str) -> None:
     async def pop(r: RedisConnectionInfo, key: str) -> None:
         try:
             async with aiotools.aclosing(
-                redis.blpop(r, key, reconnect_poll_interval=0.3),
+                redis_helper.blpop(r, key, reconnect_poll_interval=0.3),
             ) as agen:
                 async for raw_msg in agen:
                     msg = raw_msg.decode()
@@ -43,10 +42,10 @@ async def test_blist(redis_container: str, disruption_method: str) -> None:
             pass
 
     r = RedisConnectionInfo(
-        aioredis.from_url(url='redis://localhost:9379', socket_timeout=0.5),
+        redis.asyncio.from_url(url='redis://localhost:9379', socket_timeout=0.5),
         service_name=None,
     )
-    assert isinstance(r.client, aioredis.Redis)
+    assert isinstance(r.client, redis.asyncio.Redis)
     await r.client.delete("bl1")
 
     pop_task = asyncio.create_task(pop(r, "bl1"))
@@ -68,7 +67,7 @@ async def test_blist(redis_container: str, disruption_method: str) -> None:
     for i in range(5):
         # The Redis server is dead temporarily...
         if disruption_method == 'stop':
-            with pytest.raises(aioredis.exceptions.ConnectionError):
+            with pytest.raises(redis.exceptions.ConnectionError):
                 await r.client.rpush("bl1", str(5 + i))
         elif disruption_method == 'pause':
             with pytest.raises(asyncio.TimeoutError):
@@ -107,7 +106,7 @@ async def test_blist_with_retrying_rpush(redis_container: str, disruption_method
     async def pop(r: RedisConnectionInfo, key: str) -> None:
         try:
             async with aiotools.aclosing(
-                redis.blpop(r, key, reconnect_poll_interval=0.3),
+                redis_helper.blpop(r, key, reconnect_poll_interval=0.3),
             ) as agen:
                 async for raw_msg in agen:
                     msg = raw_msg.decode()
@@ -116,10 +115,10 @@ async def test_blist_with_retrying_rpush(redis_container: str, disruption_method
             pass
 
     r = RedisConnectionInfo(
-        aioredis.from_url(url='redis://localhost:9379', socket_timeout=0.5),
+        redis.asyncio.from_url(url='redis://localhost:9379', socket_timeout=0.5),
         service_name=None,
     )
-    assert isinstance(r.client, aioredis.Redis)
+    assert isinstance(r.client, redis.asyncio.Redis)
     await r.client.delete("bl1")
 
     pop_task = asyncio.create_task(pop(r, "bl1"))
@@ -134,7 +133,7 @@ async def test_blist_with_retrying_rpush(redis_container: str, disruption_method
     await asyncio.sleep(0)
 
     for i in range(5):
-        await redis.execute(r, lambda r: r.rpush("bl1", str(i)))
+        await redis_helper.execute(r, lambda r: r.rpush("bl1", str(i)))
         await asyncio.sleep(0.1)
     do_pause.set()
     await paused.wait()
@@ -145,13 +144,13 @@ async def test_blist_with_retrying_rpush(redis_container: str, disruption_method
 
     wakeup_task = asyncio.create_task(wakeup())
     for i in range(5):
-        await redis.execute(r, lambda r: r.rpush("bl1", str(5 + i)))
+        await redis_helper.execute(r, lambda r: r.rpush("bl1", str(5 + i)))
         await asyncio.sleep(0.1)
     await wakeup_task
 
     await unpaused.wait()
     for i in range(5):
-        await redis.execute(r, lambda r: r.rpush("bl1", str(10 + i)))
+        await redis_helper.execute(r, lambda r: r.rpush("bl1", str(10 + i)))
         await asyncio.sleep(0.1)
 
     await interrupt_task
@@ -183,7 +182,7 @@ async def test_blist_cluster_sentinel(
     async def pop(s: RedisConnectionInfo, key: str) -> None:
         try:
             async with aiotools.aclosing(
-                redis.blpop(
+                redis_helper.blpop(
                     s, key,
                     reconnect_poll_interval=0.3,
                     service_name="mymaster",
@@ -196,14 +195,14 @@ async def test_blist_cluster_sentinel(
             pass
 
     s = RedisConnectionInfo(
-        aioredis.sentinel.Sentinel(
+        redis.asyncio.Sentinel(
             redis_cluster.sentinel_addrs,
             password='develove',
             socket_timeout=0.5,
         ),
         service_name='mymaster',
     )
-    await redis.execute(s, lambda r: r.delete("bl1"))
+    await redis_helper.execute(s, lambda r: r.delete("bl1"))
 
     pop_task = asyncio.create_task(pop(s, "bl1"))
     interrupt_task = asyncio.create_task(interrupt(
@@ -218,7 +217,7 @@ async def test_blist_cluster_sentinel(
     await asyncio.sleep(0)
 
     for i in range(5):
-        await redis.execute(
+        await redis_helper.execute(
             s,
             lambda r: r.rpush("bl1", str(i)),
             service_name="mymaster",
@@ -233,7 +232,7 @@ async def test_blist_cluster_sentinel(
 
     wakeup_task = asyncio.create_task(wakeup())
     for i in range(5):
-        await redis.execute(
+        await redis_helper.execute(
             s,
             lambda r: r.rpush("bl1", str(5 + i)),
             service_name="mymaster",
@@ -243,7 +242,7 @@ async def test_blist_cluster_sentinel(
 
     await unpaused.wait()
     for i in range(5):
-        await redis.execute(
+        await redis_helper.execute(
             s,
             lambda r: r.rpush("bl1", str(10 + i)),
             service_name="mymaster",

--- a/tests/redis/test_pipeline.py
+++ b/tests/redis/test_pipeline.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from unittest import mock
 
-import aioredis
-import aioredis.client
-import aioredis.sentinel
+import redis.asyncio
+import redis.asyncio.client
+import redis.asyncio.sentinel
 import pytest
 
-from ai.backend.common.redis import execute
+from ai.backend.common.redis_helper import execute
 from ai.backend.common.types import RedisConnectionInfo
 
 from .types import RedisClusterInfo
@@ -17,11 +17,11 @@ from .types import RedisClusterInfo
 @pytest.mark.asyncio
 async def test_pipeline_single_instance(redis_container: str) -> None:
     rconn = RedisConnectionInfo(
-        aioredis.from_url(url='redis://localhost:9379', socket_timeout=0.5),
+        redis.asyncio.from_url(url='redis://localhost:9379', socket_timeout=0.5),
         service_name=None,
     )
 
-    def _build_pipeline(r: aioredis.Redis) -> aioredis.client.Pipeline:
+    def _build_pipeline(r: redis.asyncio.Redis) -> redis.asyncio.client.Pipeline:
         pipe = r.pipeline(transaction=False)
         pipe.set("xyz", "123")
         pipe.incr("xyz")
@@ -34,7 +34,7 @@ async def test_pipeline_single_instance(redis_container: str) -> None:
     actual_value = await execute(rconn, lambda r: r.get("xyz"))
     assert actual_value == b"124"
 
-    async def _build_pipeline_async(r: aioredis.Redis) -> aioredis.client.Pipeline:
+    async def _build_pipeline_async(r: redis.asyncio.Redis) -> redis.asyncio.client.Pipeline:
         pipe = r.pipeline(transaction=False)
         pipe.set("abc", "123")
         pipe.incr("abc")
@@ -52,19 +52,19 @@ async def test_pipeline_single_instance(redis_container: str) -> None:
 @pytest.mark.asyncio
 async def test_pipeline_single_instance_retries(redis_container: str) -> None:
     rconn = RedisConnectionInfo(
-        aioredis.from_url(url='redis://localhost:9379', socket_timeout=0.5),
+        redis.asyncio.from_url(url='redis://localhost:9379', socket_timeout=0.5),
         service_name=None,
     )
 
     build_count = 0
 
     patcher = mock.patch(
-        'aioredis.client.Pipeline._execute_pipeline',
+        'redis.asyncio.client.Pipeline._execute_pipeline',
         side_effect=[ConnectionResetError, ConnectionResetError, mock.DEFAULT],
     )
     patcher.start()
 
-    def _build_pipeline(r: aioredis.Redis) -> aioredis.client.Pipeline:
+    def _build_pipeline(r: redis.asyncio.Redis) -> redis.asyncio.client.Pipeline:
         nonlocal build_count, patcher
         build_count += 1
         if build_count == 3:
@@ -86,12 +86,12 @@ async def test_pipeline_single_instance_retries(redis_container: str) -> None:
     build_count = 0
 
     patcher = mock.patch(
-        'aioredis.client.Pipeline._execute_pipeline',
+        'redis.asyncio.client.Pipeline._execute_pipeline',
         side_effect=[ConnectionResetError, ConnectionResetError, mock.DEFAULT],
     )
     patcher.start()
 
-    async def _build_pipeline_async(r: aioredis.Redis) -> aioredis.client.Pipeline:
+    async def _build_pipeline_async(r: redis.asyncio.Redis) -> redis.asyncio.client.Pipeline:
         nonlocal build_count, patcher
         build_count += 1
         if build_count == 3:
@@ -115,7 +115,7 @@ async def test_pipeline_single_instance_retries(redis_container: str) -> None:
 @pytest.mark.asyncio
 async def test_pipeline_sentinel_cluster(redis_cluster: RedisClusterInfo) -> None:
     rconn = RedisConnectionInfo(
-        aioredis.sentinel.Sentinel(
+        redis.asyncio.sentinel.Sentinel(
             redis_cluster.sentinel_addrs,
             password='develove',
             socket_timeout=0.5,
@@ -123,7 +123,7 @@ async def test_pipeline_sentinel_cluster(redis_cluster: RedisClusterInfo) -> Non
         service_name='mymaster',
     )
 
-    def _build_pipeline(r: aioredis.Redis) -> aioredis.client.Pipeline:
+    def _build_pipeline(r: redis.asyncio.Redis) -> redis.asyncio.client.Pipeline:
         pipe = r.pipeline(transaction=False)
         pipe.set("xyz", "123")
         pipe.incr("xyz")

--- a/tests/redis/utils.py
+++ b/tests/redis/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import aioredis
-import aioredis.exceptions
+import redis.asyncio
+import redis.exceptions
 import async_timeout
 import asyncio
 import functools
@@ -41,20 +41,20 @@ async def simple_run_cmd(cmdargs: Sequence[Union[str, bytes]], **kwargs) -> asyn
 
 
 async def wait_redis_ready(host: str, port: int, password: str = None) -> None:
-    r = aioredis.from_url(f"redis://{host}:{port}", password=password, socket_timeout=0.2)
+    r = redis.asyncio.from_url(f"redis://{host}:{port}", password=password, socket_timeout=0.2)
     while True:
         try:
             print("CheckReady.PING", port, file=sys.stderr)
             await r.ping()
             print("CheckReady.PONG", port, file=sys.stderr)
-        except aioredis.exceptions.AuthenticationError:
+        except redis.exceptions.AuthenticationError:
             raise
         except (
             ConnectionResetError,
-            aioredis.exceptions.ConnectionError,
+            redis.exceptions.ConnectionError,
         ):
             await asyncio.sleep(0.1)
-        except aioredis.exceptions.TimeoutError:
+        except redis.exceptions.TimeoutError:
             pass
         else:
             break

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -18,7 +18,7 @@ from ai.backend.common.types import (
     EtcdRedisConfig,
     HostPortPair,
 )
-from ai.backend.common import redis
+from ai.backend.common import redis_helper
 
 
 @attr.s(slots=True, frozen=True)
@@ -71,7 +71,7 @@ async def test_dispatch(redis_container) -> None:
     await asyncio.sleep(0.2)
     assert records == {'async', 'sync'}
 
-    await redis.execute(producer.redis_client, lambda r: r.flushdb())
+    await redis_helper.execute(producer.redis_client, lambda r: r.flushdb())
     await producer.close()
     await dispatcher.close()
 
@@ -118,7 +118,7 @@ async def test_error_on_dispatch(redis_container) -> None:
     assert 'ZeroDivisionError' in exception_log
     assert 'OverflowError' in exception_log
 
-    await redis.execute(producer.redis_client, lambda r: r.flushdb())
+    await redis_helper.execute(producer.redis_client, lambda r: r.flushdb())
     await producer.close()
     await dispatcher.close()
 


### PR DESCRIPTION
Redis v4.2.1 now contains aioredis as its part: `redis.asyncio`.
Let's use it to get the latest community support and official feature updates.