### PR TITLE
fix: Add error logs to notify ConnectionError caused by incorrect redis url

### DIFF
--- a/changes/139.fix
+++ b/changes/139.fix
@@ -1,0 +1,1 @@
+Add error logs to notify ConnectionError caused by incorrect redis url.

--- a/changes/139.fix
+++ b/changes/139.fix
@@ -1,1 +1,1 @@
-Add error logs to notify ConnectionError caused by incorrect redis url.
+Add explicit error logs to inform occurrence of `aioredis.exceptions.ConnectionError` because incorrect server URLs and temporary network failures are indistinguishable but should be diagnosable

--- a/src/ai/backend/common/redis.py
+++ b/src/ai/backend/common/redis.py
@@ -269,7 +269,8 @@ async def execute(
             aioredis.sentinel.SlaveNotFoundError,
             aioredis.exceptions.ReadOnlyError,
             ConnectionResetError,
-        ):
+        ) as e:
+            log.error(e)
             await asyncio.sleep(reconnect_poll_interval)
             continue
         except aioredis.exceptions.ResponseError as e:

--- a/src/ai/backend/common/redis.py
+++ b/src/ai/backend/common/redis.py
@@ -262,16 +262,16 @@ async def execute(
                         return newdict
                 else:
                     return result
-        except aioredis.exceptions.ConnectionError as e:
-            log.exception(f'execute(): Connecting to redis failed: {e}')
-            await asyncio.sleep(reconnect_poll_interval)
-            continue
         except (
             aioredis.sentinel.MasterNotFoundError,
             aioredis.sentinel.SlaveNotFoundError,
             aioredis.exceptions.ReadOnlyError,
             ConnectionResetError,
         ):
+            await asyncio.sleep(reconnect_poll_interval)
+            continue
+        except aioredis.exceptions.ConnectionError as e:
+            log.exception(f'execute(): Connecting to redis failed: {e}')
             await asyncio.sleep(reconnect_poll_interval)
             continue
         except aioredis.exceptions.ResponseError as e:

--- a/src/ai/backend/common/redis.py
+++ b/src/ai/backend/common/redis.py
@@ -4,7 +4,6 @@ import asyncio
 import inspect
 import logging
 import socket
-import sys
 from typing import (
     Any,
     AsyncIterator,


### PR DESCRIPTION
Given an incorrect redis url, there occurs an `aioredis.exceptions.ConnectionError` when trying to run a command with it. Therefore, I made some changes to fix two problems.

1. ([backend.ai-manager](https://github.com/lablup/backend.ai-manager)) Added a coroutine function, `ai.backend.common.redis.pool_redis_connection`, to check redis connection explicitly. This runs `aioredis.client.Redis.time()` to test if connection is built and raises a `aioredis.exceptions.ConnectionError` with printing additional error message when unable to connect to redis server.
2. ([backend.ai-agent](https://github.com/lablup/backend.ai-agent)) I found that there happens an infinite loop in `ai.backend.common.redis.execute` when unable to connect to redis server, especially with incorrect url which has no chance to get recovered in runtime. Therefore, I added a line to log error message so that user can recognize at least what's going on.

Refs:
- lablup/backend.ai#424