### PR TITLE
feat: Add a watchdog task to `FileLock`

### DIFF
--- a/changes/140.feature.md
+++ b/changes/140.feature.md
@@ -1,0 +1,1 @@
+Add a watchdog task to `FileLock` to unlock explicitly after specified lifetime.

--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -113,6 +113,7 @@ class FileLock(AbstractDistributedLock):
 
     async def __aenter__(self) -> None:
         await self.acquire()
+        return self
 
     async def __aexit__(self, *exc_info) -> bool | None:
         self.release()

--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -93,7 +93,7 @@ class FileLock(AbstractDistributedLock):
                         log.debug("file lock acquired: {}", self._path)
                     if self._lifetime is not None:
                         self._watchdog_task = asyncio.create_task(
-                            self._watchdog_timer(ttl=self._lifetime,)
+                            self._watchdog_timer(ttl=self._lifetime),
                         )
         except RetryError:
             raise asyncio.TimeoutError(f"failed to lock file: {self._path}")

--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -119,10 +119,8 @@ class FileLock(AbstractDistributedLock):
         self.release()
         return None
 
-    async def _watchdog_timer(self, ttl: float, interval: float = 0.03):
-        while ttl > 0:
-            await asyncio.sleep(interval)
-            ttl -= interval
+    async def _watchdog_timer(self, ttl: float):
+        await asyncio.sleep(ttl)
         if self._locked:
             fcntl.flock(self._fp, fcntl.LOCK_UN)
             self._locked = False


### PR DESCRIPTION
I added a new coroutine named `FileLock._watchdog_timer` in this PR. This works like a [Watchdog](https://en.wikipedia.org/wiki/Watchdog_timer), it explicitly unlock the resource if its holder is still holding it after the given `ttl` has passed.

Also wrote a test code to verify it and passed the test.

Refs:
- lablup/backend.ai#413